### PR TITLE
Add support for status filter in subscribers and listsubscribers get methods

### DIFF
--- a/ClearstreamDotNetFramework/Enum.cs
+++ b/ClearstreamDotNetFramework/Enum.cs
@@ -36,5 +36,16 @@ namespace ClearstreamDotNetFramework
             FIRST,
             NEW
         }
+
+        /// <summary>
+        /// Subscriber search status options.
+        /// </summary>
+        public enum SubscriberStatus
+        {
+            ACTIVE,
+            INACTIVE,
+            OPTOUT,
+            ANY
+        }
     }
 }

--- a/ClearstreamDotNetFramework/Properties/AssemblyInfo.cs
+++ b/ClearstreamDotNetFramework/Properties/AssemblyInfo.cs
@@ -35,4 +35,4 @@ using System.Runtime.InteropServices;
 [assembly: Guid( "6fb4d1a8-5f86-454d-94bb-fc1365523330" )]
 
 // Auto increment assembly versions
-[assembly: AssemblyVersion( "1.4.*" )]
+[assembly: AssemblyVersion( "1.5.*" )]

--- a/ClearstreamDotNetFramework/v1/Endpoints/Lists.cs
+++ b/ClearstreamDotNetFramework/v1/Endpoints/Lists.cs
@@ -151,7 +151,7 @@ namespace ClearstreamDotNetFramework.v1
         /// <param name="mobileNumber">The mobile number to search for in the list.</param>
         /// <param name="searchOperator">The search operator to use if multiple search params are provided.</param>
         /// <returns></returns>
-        public SubscribersResponse GetListSubscribers( int id, int? limit = null, int? page = null, string firstName = null, string lastName = null, string mobileNumber = null, SearchOperator searchOperator = SearchOperator.AND )
+        public SubscribersResponse GetListSubscribers( int id, int? limit = null, int? page = null, string firstName = null, string lastName = null, string mobileNumber = null, SearchOperator searchOperator = SearchOperator.AND, SubscriberStatus status = SubscriberStatus.ACTIVE )
         {
             var request = new RestRequest( $"lists/{id}/subscribers" );
             request.Method = Method.GET;
@@ -186,12 +186,29 @@ namespace ClearstreamDotNetFramework.v1
                 searchParams = searchParams + 1;
             }
 
+            request.AddParameter( "status", status, ParameterType.GetOrPost );
+            searchParams = searchParams + 1;
+
             if ( searchParams > 1 )
             {
                 request.AddParameter( "operator", searchOperator.ToString(), ParameterType.GetOrPost );
             }
 
             return Execute<SubscribersResponse>( request );
+        }
+
+        /// <summary>
+        /// Removes a subscriber from a list. https://api-docs.clearstream.io/#delete-a-subscriber
+        /// </summary>
+        /// <param name="mobileNumber">The mobile number.</param>
+        /// <param name="listId">The list id.</param>
+        /// <returns></returns>
+        public ListResponse DeleteListSubscriber( string mobileNumber, int listId )
+        {
+            var request = new RestRequest( $"lists/{listId}/subscribers/{mobileNumber}" );
+            request.Method = Method.DELETE;
+
+            return Execute<ListResponse>( request );
         }
     }
 }

--- a/ClearstreamDotNetFramework/v1/Endpoints/Lists.cs
+++ b/ClearstreamDotNetFramework/v1/Endpoints/Lists.cs
@@ -186,7 +186,7 @@ namespace ClearstreamDotNetFramework.v1
                 searchParams = searchParams + 1;
             }
 
-            request.AddParameter( "status", status, ParameterType.GetOrPost );
+            request.AddParameter( "status", status.ToString(), ParameterType.GetOrPost );
             searchParams = searchParams + 1;
 
             if ( searchParams > 1 )

--- a/ClearstreamDotNetFramework/v1/Endpoints/Subscribers.cs
+++ b/ClearstreamDotNetFramework/v1/Endpoints/Subscribers.cs
@@ -179,7 +179,7 @@ namespace ClearstreamDotNetFramework.v1
         /// <param name="lastName">The last name.</param>
         /// <param name="email">The email.</param>
         /// <returns></returns>
-        public SubscriberResponse UpdateSubscriber( string mobileNumber, string firstName = null, string lastName = null, string email = null )
+        public SubscriberResponse UpdateSubscriber( string mobileNumber, string firstName = null, string lastName = null, string email = null, List<int> lists = null )
         {
             var request = new RestRequest( $"subscribers/{mobileNumber}" );
             request.Method = Method.PATCH;
@@ -197,6 +197,11 @@ namespace ClearstreamDotNetFramework.v1
             if ( !string.IsNullOrWhiteSpace( email ) )
             {
                 request.AddParameter( "email", email, ParameterType.GetOrPost );
+            }
+
+            if ( lists != null )
+            {
+                request.AddParameter( "lists", string.Join( ",", lists.ToArray() ), ParameterType.GetOrPost );
             }
 
             return Execute<SubscriberResponse>( request );

--- a/ClearstreamDotNetFramework/v1/Endpoints/Subscribers.cs
+++ b/ClearstreamDotNetFramework/v1/Endpoints/Subscribers.cs
@@ -34,7 +34,7 @@ namespace ClearstreamDotNetFramework.v1
         /// <param name="mobileNumber">The mobile number to search for.</param>
         /// <param name="searchOperator">The search operator to use if multiple search params are provided.</param>
         /// <returns></returns>
-        public SubscribersResponse GetSubscribers( int? limit = null, int? page = null, string firstName = null, string lastName = null, string mobileNumber = null, SearchOperator searchOperator = SearchOperator.AND )
+        public SubscribersResponse GetSubscribers( int? limit = null, int? page = null, string firstName = null, string lastName = null, string mobileNumber = null, SearchOperator searchOperator = SearchOperator.AND, SubscriberStatus status = SubscriberStatus.ACTIVE )
         {
             var request = new RestRequest( "subscribers" );
             request.Method = Method.GET;
@@ -68,6 +68,9 @@ namespace ClearstreamDotNetFramework.v1
                 request.AddParameter( "mobile_number", mobileNumber, ParameterType.GetOrPost );
                 searchParams = searchParams + 1;
             }
+
+            request.AddParameter( "status", status.ToString(), ParameterType.GetOrPost );
+            searchParams = searchParams + 1;
 
             if ( searchParams > 1 )
             {


### PR DESCRIPTION
In chatting with a Clearstream dev recently, it was communicated to me that there is an undocumented filter parameter for "status" that can be passed into the subscribers endpoint. When that parameter is not provided, the response returns only subscribers with status of "Active". I have added support to be able to use this status filter, defaulting it to Active so existing code using the current method should continue to work without impact.